### PR TITLE
 fix windows sigar, caused java.io.IOException

### DIFF
--- a/metrics-os/src/main/java/com/alibaba/metrics/os/utils/SystemInfoUtils.java
+++ b/metrics-os/src/main/java/com/alibaba/metrics/os/utils/SystemInfoUtils.java
@@ -96,6 +96,11 @@ public class SystemInfoUtils {
             path = path.substring(path.indexOf(":") + 1);
         }
 
+        //fix windows sigar
+        if(path != null && path.startsWith("file:/")) {
+            path = path.substring(6);
+        }
+
         File file = new File(path);
 
         if (!file.exists()) {


### PR DESCRIPTION
 fix windows sigar, caused java.io.IOException

full stackstrace:

```
七月 12, 2021 2:48:02 下午 com.alibaba.metrics.rest.server.jersey.HttpHandlerContainer handle
警告: Error handling request: 
java.lang.NullPointerException
	at com.alibaba.metrics.os.windows.CpuUsageGaugeSet.collectCpuInfo(CpuUsageGaugeSet.java:118)
	at com.alibaba.metrics.os.windows.CpuUsageGaugeSet.getValueInternal(CpuUsageGaugeSet.java:145)
	at com.alibaba.metrics.CachedMetricSet.refreshIfNecessary(CachedMetricSet.java:61)
	at com.alibaba.metrics.os.windows.CpuUsageGaugeSet$2.getValue(CpuUsageGaugeSet.java:194)
	at com.alibaba.metrics.os.windows.CpuUsageGaugeSet$2.getValue(CpuUsageGaugeSet.java:191)
	at com.alibaba.metrics.common.NormalMetricsCollector.collect(NormalMetricsCollector.java:135)
	at com.alibaba.metrics.rest.MetricsResource.buildMetricRegistry(MetricsResource.java:372)
	at com.alibaba.metrics.rest.MetricsResource.buildMetricRegistry(MetricsResource.java:359)
	at com.alibaba.metrics.rest.MetricsResource.listMetrics(MetricsResource.java:98)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:76)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:148)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:191)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:200)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:103)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:493)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:415)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:104)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:277)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:272)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:268)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:316)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:298)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:268)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:289)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:256)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:703)
	at com.alibaba.metrics.rest.server.jersey.HttpHandlerContainer.handle(HttpHandlerContainer.java:133)
	at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
	at sun.net.httpserver.AuthFilter.doFilter(AuthFilter.java:83)
	at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:82)
	at sun.net.httpserver.ServerImpl$Exchange$LinkHandler.handle(ServerImpl.java:675)
	at com.sun.net.httpserver.Filter$Chain.doFilter(Filter.java:79)
	at sun.net.httpserver.ServerImpl$Exchange.run(ServerImpl.java:647)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

#63 