### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ after_success:
 cache:
   directories:
   - $HOME/.m2
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.