### PR TITLE
fix flaky test in TestAlibabaMetricsExports.java

### DIFF
--- a/metrics-prometheus/src/test/java/com/alibaba/metrics/prometheus/TestAlibabaMetricsExports.java
+++ b/metrics-prometheus/src/test/java/com/alibaba/metrics/prometheus/TestAlibabaMetricsExports.java
@@ -268,8 +268,8 @@ public class TestAlibabaMetricsExports {
         Assert.assertEquals("prom_test_fastcompass_bucket_count", samples.get(0).samples.get(0).name);
         Assert.assertEquals("success count", 5, samples.get(0).samples.get(0).value, 0.0001d);
         Assert.assertEquals("failure count", 5, samples.get(0).samples.get(1).value, 0.0001d);
-        Assert.assertEquals("success sum", successSum, samples.get(0).samples.get(2).value, 0.0001d);
-        Assert.assertEquals("failure sum", failureSum, samples.get(0).samples.get(3).value, 0.0001d);
+        Assert.assertTrue("success sum", successSum==(int)samples.get(0).samples.get(2).value || successSum==(int)samples.get(0).samples.get(3).value);
+        Assert.assertTrue("failure sum", failureSum==(int)samples.get(0).samples.get(2).value || failureSum==(int)samples.get(0).samples.get(3).value);
     }
 
     @After


### PR DESCRIPTION
Hi, 

When I was testing metrics using [NonDex](https://github.com/TestingResearchIllinois/NonDex) with the following command: `mvn -pl metrics-prometheus  edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.alibaba.metrics.prometheus.TestAlibabaMetricsExports#testExportFastCompass`,

`testExportFastCompass()` is reported as flaky. This is because `collect()` method calls `fromFastCompass`, which adds elements in hashmaps into a list. The order of insertion is not deterministic, and therefore the output list order is not deterministic either. I fixed this test by comparing the expected value equal to the sample element at either position. 